### PR TITLE
Use `<building code> <room number>` for pasing building codes

### DIFF
--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -299,14 +299,20 @@ class UNL_Peoplefinder
     {
         static $bldgs = false;
 
-        $regex = "/([A-Za-z0-9].) ([A-Z0-9\&]{2,4})/" ; //& is for M&N Building
+        if (!$bldgs) {
+            $bldgs = new UNL_Common_Building();
+        }
+
+        $regex = "/^([A-Z0-9&]{2,4}) /"; //& is for M&N Building
 
         if (preg_match($regex, $address, $matches)) {
+            if ($bldgs->buildingExists($matches[1])) {
+                return $matches[1];
+            }
+        }
 
-            if (!$bldgs) {
-                $bldgs = new UNL_Common_Building();
-            }            
-
+        $regex = "/([A-Za-z0-9].) ([A-Z0-9&]{2,4})/"; //& is for M&N Building
+        if (preg_match($regex, $address, $matches)) {
             if ($bldgs->buildingExists($matches[2])) {
                 return $matches[2];
             }


### PR DESCRIPTION
It appears that HR is changing the format of their addresses.  This will first check for the new format and then attempt to parse the old format.