### PR TITLE
Add caching functionality to Digital Measures API

### DIFF
--- a/examples/facultyDataTest.php
+++ b/examples/facultyDataTest.php
@@ -1,0 +1,6 @@
+<?php
+require_once dirname(__FILE__) . '/../www/config.inc.php';
+
+$person = new UNL_Peoplefinder_Person(array('uid' => 'lperez1', 'peoplefinder' => NULL));
+
+var_dump($person);

--- a/www/config-sample.inc.php
+++ b/www/config-sample.inc.php
@@ -40,3 +40,7 @@ UNL_Officefinder::$admins = array('bbieber2', 'smeranda2', 'erasmussen2');
 
 UNL_Knowledge_Driver_REST::$service_user = 'unl/web_service_unlwebcv';
 UNL_Knowledge_Driver_REST::$service_pass = 'examplepassword';
+
+# set the memcache host and port
+UNL_Knowledge_Driver_REST::$memcache_host = 'localhost';
+UNL_Knowledge_Driver_REST::$memcache_port = 11211;

--- a/www/templates/html/Knowledge.tpl.php
+++ b/www/templates/html/Knowledge.tpl.php
@@ -32,7 +32,7 @@
 
 <?php if ($context->papers) { ?>
     <div class="directory-knowledge-section directory-knowledge-section-papers">
-        <h3 class="wdn-brand"><img src="images/icons/document-1.svg" alt="">Papers</h3>
+        <h3 class="wdn-brand"><img src="images/icons/document-1.svg" alt="">Publications and Other Intellectual Contributions</h3>
         <ul class="directory-knowledge-section-inner">
             <?php foreach ($context->papers as $paper) { ?>
                 <li class="directory-knowledge-item">


### PR DESCRIPTION
Used memcached to cache results for the API for one week. Should be easy
to set up and add into PHP. Be sure to copy over the settings from
config.sample.php into the config.inc.php file and make the appropriate
changes if necessary.