### PR TITLE
Restore editor permissions

### DIFF
--- a/src/UNL/Officefinder/Department.php
+++ b/src/UNL/Officefinder/Department.php
@@ -174,6 +174,9 @@ class UNL_Officefinder_Department extends UNL_Officefinder_Record_NestedSetAdjac
         }
 
         if (!isset($this->internal['canEdit'])) {
+            //default to false
+            $this->internal['canEdit'] = false;
+            
             if (isset($this->id) && (bool) UNL_Officefinder_Department_Permission::getById($this->id, $user)) {
                 $this->internal['canEdit'] = true;
             }
@@ -181,8 +184,6 @@ class UNL_Officefinder_Department extends UNL_Officefinder_Record_NestedSetAdjac
             if (isset($this->parent_id) && true === UNL_Officefinder_Department::getByID($this->parent_id)->userCanEdit($user)) {
                 $this->internal['canEdit'] = true;
             }
-
-            $this->internal['canEdit'] = false;
         }
 
         return $this->internal['canEdit'];


### PR DESCRIPTION
Move the default assignment of `false` to before permission check logic. The permission check logic will only change the value to `true` if they have permission. This was always returning false.

@kabel I *think* this works, but I am unable to test locally due to pear issue. Can you verify that it fixes the issue?