### PR TITLE
Minor cleanup of the StandardFilter

### DIFF
--- a/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class builds a pretty good LDAP filter for searching for people.
- * 
+ *
  * <code>
  * <?php
  * $filter = new UNL_Peoplefinder_StandardFilter('brett bieber','|',false);
@@ -11,8 +11,8 @@
  * </code>
  *
  * PHP version 5
- * 
- * @category  Default 
+ *
+ * @category  Default
  * @package   UNL_Peoplefinder
  * @author    Brett Bieber <brett.bieber@gmail.com>
  * @copyright 2007 Regents of the University of Nebraska
@@ -22,7 +22,7 @@
 class UNL_Peoplefinder_Driver_LDAP_StandardFilter
 {
     protected $_filter;
-    
+
     protected $_excludeRecords = array();
 
     public static $searchFields = array(
@@ -32,7 +32,7 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
             'sn',
             'eduPersonNickname'
         );
-    
+
     /**
      * Construct a standard filter.
      *
@@ -99,7 +99,7 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
             $this->_excludeRecords = $records;
         }
     }
-    
+
     protected function addExcludedRecords()
     {
         if (count($this->_excludeRecords)) {
@@ -110,7 +110,7 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
             $this->_filter = '(&'.$this->_filter.'(!(|'.$excludeFilter.')))';
         }
     }
-    
+
     function __toString()
     {
         $this->addExcludedRecords();

--- a/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
@@ -48,9 +48,13 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
 
             //escape query
             $inquery = UNL_Peoplefinder_Driver_LDAP_Util::escape_filter_value($inquery);
-            
+
             //put the query into an array of words
             $query = preg_split('/\s+/', $inquery, 4);
+            if (count($query) > 1) {
+                //add the original multi-word query as a search term
+                $query[] = $inquery;
+            }
 
             if ($operator != '&') {
                 $operator = '|';
@@ -78,22 +82,10 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
                 $filter .= ")";
             }
             $filter .= ")";
-
-            //determine if a wildcard should be used
-            if ($wild) {
-                $inquery = "*$inquery*";
-            }
-
-            //and search for the string as entered
-            $as_entered = '';
-            foreach(self::$searchFields as $field) {
-                $as_entered .= "($field=$inquery)";
-            }
-            $filter = "(|(|$as_entered)$filter)";
         }
         $this->_filter = $filter;
     }
-    
+
     /**
      * Allows you to exclude specific records from a result set.
      *

--- a/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
@@ -4,10 +4,10 @@
  *
  * <code>
  * <?php
- * $filter = new UNL_Peoplefinder_StandardFilter('brett bieber','|',false);
+ * $filter = new UNL_Peoplefinder_Driver_LDAP_StandardFilter('brett bieber','|',false);
  * echo $filter;
  * ?>
- * (|(sn=brett bieber)(cn=brett bieber)(&(| (givenname=brett) (sn=brett) (mail=brett) (unlemailnickname=brett) (unlemailalias=brett))(| (givenname=bieber) (sn=bieber) (mail=bieber) (unlemailnickname=bieber) (unlemailalias=bieber))))
+ * (|(|(mail=brett)(cn=brett)(givenName=brett)(sn=brett)(eduPersonNickname=brett)(sn=brett-*)(sn=*brett))(|(mail=bieber)(cn=bieber)(givenName=bieber)(sn=bieber)(eduPersonNickname=bieber)(sn=bieber-*)(sn=*bieber))(|(mail=brett bieber)(cn=brett bieber)(givenName=brett bieber)(sn=brett bieber)(eduPersonNickname=brett bieber)(sn=brett bieber-*)(sn=*brett bieber)))
  * </code>
  *
  * PHP version 5

--- a/src/UNL/Peoplefinder/Driver/LDAP/Util.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/Util.php
@@ -94,14 +94,13 @@ abstract class UNL_Peoplefinder_Driver_LDAP_Util
     /**
      * This is used to wrap filters in global exclusion clauses.
      *
+     * If you want to quickly exclude someone:
+     * return "(&$filter(!(uid=bbieber2)))";
+     *
      * @param $filter
      */
     public static function wrapGlobalExclusions($filter)
     {
-        return
-            '(&'
-            . $filter
-            . '(!(eduPersonPrimaryAffiliation=guest))' .
-            ')';
+        return $filter;
     }
 }


### PR DESCRIPTION
After studying the filter for possible improvements I found a few issues.
Single word queries were being doubled up in the filter at the `//and search for the string as entered` section. This should only be done if the query has more than one word.

Remove the `!eduPersonPrimaryAffiliation=guest` query as it had no effect.

Closes #34 