### PR TITLE
cache LDAP queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 services:
   - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: php
+services:
+  - memcached
 before_script: composer install
 script: phpunit --verbose --bootstrap www/config-sample.inc.php tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 services:
   - memcached
-before_script: composer install
+before_script:
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - composer install
 script: phpunit --verbose --bootstrap www/config-sample.inc.php tests

--- a/src/UNL/Peoplefinder/SearchController.php
+++ b/src/UNL/Peoplefinder/SearchController.php
@@ -81,7 +81,7 @@ class UNL_Peoplefinder_SearchController
             $search_method = $this->options['method'];
         }
 
-        if (!is_array($this->options['q']) && strlen($this->options['q']) <= 3) {
+        if (!is_array($this->options['q']) && strlen($this->options['q']) <= 2) {
             throw new UNL_Peoplefinder_InvalidArgumentException('Too few characters were entered.');
         }
 


### PR DESCRIPTION
Some LDAP queries, especially those with 3 character searches could take quite some time. This will cache all LDAP queries for a default of 8 hours, as well as prevent cache stampedes by returning an empty result set until the original query finishes.

