### PR TITLE
Remove empty parts of a query

### DIFF
--- a/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/StandardFilter.php
@@ -51,6 +51,11 @@ class UNL_Peoplefinder_Driver_LDAP_StandardFilter
             
             //put the query into an array of words
             $query = preg_split('/\s+/', $inquery, 4);
+            
+            //remove empty parts
+            $query = array_filter($query, function($value) {
+                return !empty($value);
+            });
 
             if ($operator != '&') {
                 $operator = '|';


### PR DESCRIPTION
Searches with extra spaces like `michael ` or `michael   fairchild` were causing invalid filters to be created.