### PR TITLE
Return the original profile icon URL which should always work

### DIFF
--- a/src/UNL/Peoplefinder/Record/Avatar.php
+++ b/src/UNL/Peoplefinder/Record/Avatar.php
@@ -158,7 +158,7 @@ class UNL_Peoplefinder_Record_Avatar implements UNL_Peoplefinder_DirectOutput, U
         if ($effectiveUrl == $profileIconUrl) {
             if ($response->getStatus() == 200) {
                 //The old version of planetred is in use and will return a 200 response for images.
-                return $effectiveUrl;
+                return $profileIconUrl;
             }
             
             //request to planet red failed (404 or 500 like error) however
@@ -166,10 +166,10 @@ class UNL_Peoplefinder_Record_Avatar implements UNL_Peoplefinder_DirectOutput, U
             $fallbackUrl = 'mm';
         } elseif (false === strpos($effectiveUrl, 'user/default') && false === strpos($effectiveUrl, 'mod/profile/graphics/default')) {
             //looks like it isn't the default image. Serve this this one up.
-            return $effectiveUrl;
+            return $profileIconUrl;
         } else {
             //default image again.
-            $fallbackUrl = $effectiveUrl;
+            $fallbackUrl = $profileIconUrl;
         }
 
         $gravatarParams = [


### PR DESCRIPTION
I find this a little difficult to explain, but I will try anyway. The DNS record for planetred might not be the same in directory.unl.edu and gravatar. Because DNS can take some time to propagate, directory will get the new ip address before gravatar. By sending the effective URL to gravatar, there is a potential that the URL might not exist because gravatar is still referring to the old server. By sending the `$profileIconUrl` to gravatar, the request is bound to work regardless of gravatar's dns cache.

The same goes with clients. Client computers might not have the same DNS record as directory.unl.edu and therefor URLs might not resolve correctly.