### PR TITLE
Remove conflicting caches

### DIFF
--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -85,19 +85,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             $peoplefinder = UNL_Peoplefinder::getInstance();
         }
 
-        $cache = UNL_Peoplefinder_Cache::factory();
-        $cacheKey = 'UNL_Peoplefinder_Record-uid-' . $uid;
-
-        $remoteRecord = $cache->get($cacheKey);
-        if (!$remoteRecord) {
-            $remoteRecord = $peoplefinder->getUID($uid);
-
-            if ($remoteRecord) {
-                $cache->set($cacheKey, $remoteRecord);
-            }
-        }
-
-        return $remoteRecord;
+        return $peoplefinder->getUID($uid);
     }
 
     public static function getCleanPhoneNumber($phone)


### PR DESCRIPTION
The query is already bing cached at the driver level for a default of 8 hours, while this was caching results for a day. This could lead to not only duplicate caches but also confusion as to how long it will take for the record to leave the cache.

This probably fixes some issues related #51 but there still might be others.
