### PR TITLE
Fix script that suppresses official units w/o children and employees

### DIFF
--- a/scripts/flag_sap_orgs_without_employees.php
+++ b/scripts/flag_sap_orgs_without_employees.php
@@ -15,7 +15,7 @@ $db->query('UPDATE departments SET suppress = 0;');
 
 // Step 2.) Suppress all departments with (no children AND no hr personnel)
 $departments = new UNL_Officefinder_DepartmentList_OfficialOrgUnitsNoChildren();
-$departments_with_nohrpersonnel = new UNL_Officefinder_DepartmentList_Filter_HasNoHRPersonnel($departments_without_children);
+$departments_with_nohrpersonnel = new UNL_Officefinder_DepartmentList_Filter_HasNoHRPersonnel($departments);
 
 foreach ($departments_with_nohrpersonnel as $department) {
     /* @var $department UNL_Officefinder_Department */

--- a/scripts/flag_sap_orgs_without_employees.php
+++ b/scripts/flag_sap_orgs_without_employees.php
@@ -5,16 +5,16 @@
  */
 require_once dirname(__FILE__).'/../www/config.inc.php';
 
+// seed the peoplefinder instance with configured driver
+UNL_Peoplefinder::getInstance(isset($driver) ? ['driver' => $driver] : []);
+
 // Step 1.) Reset suppress flag on all departments to false (0)
 $db = UNL_Officefinder::getDB();
 $db->query('UPDATE departments SET suppress = 0;');
 
 
 // Step 2.) Suppress all departments with (no children AND no hr personnel)
-$departments = new UNL_Officefinder_DepartmentList_OfficialOrgUnits();
-
-$departments_without_children = new UNL_Officefinder_DepartmentList_Filter_HasNoChildren($departments);
-
+$departments = new UNL_Officefinder_DepartmentList_OfficialOrgUnitsNoChildren();
 $departments_with_nohrpersonnel = new UNL_Officefinder_DepartmentList_Filter_HasNoHRPersonnel($departments_without_children);
 
 foreach ($departments_with_nohrpersonnel as $department) {

--- a/src/UNL/Officefinder/DepartmentList/OfficialOrgUnitsNoChildren.php
+++ b/src/UNL/Officefinder/DepartmentList/OfficialOrgUnitsNoChildren.php
@@ -1,0 +1,16 @@
+<?php
+class UNL_Officefinder_DepartmentList_OfficialOrgUnitsNoChildren extends UNL_Officefinder_DepartmentList_NameSearch
+{
+    public function getSQL()
+    {
+        return 'SELECT d.*
+FROM departments d
+LEFT JOIN (
+  SELECT parent_id
+  FROM departments
+  WHERE parent_id IS NOT NULL
+  GROUP BY parent_id
+) p ON d.id = p.parent_id
+WHERE d.org_unit IS NOT NULL AND p.parent_id IS NULL';
+    }
+}

--- a/src/UNL/Peoplefinder/Department.php
+++ b/src/UNL/Peoplefinder/Department.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Class which represents a department.
- * 
+ *
  * The departments are pulled from an xml file, generated from SAP data.
  * hr_tree.xml using TreeML schema
- * 
+ *
  * The object also allows iterating over all the members of the department.
  */
 class UNL_Peoplefinder_Department implements Countable, Iterator
@@ -15,7 +15,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      * @var string
      */
     public $name;
-    
+
     /**
      * The organizational unit number.
      *
@@ -26,49 +26,49 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
     /**
      * Organization abbreviation
      *
-     * @var string 
+     * @var string
      */
     public $org_abbr;
-    
+
     /**
      * Building the department main office is in.
      *
      * @var string
      */
     public $building;
-    
+
     /**
      * Room
      *
      * @var string
      */
     public $room;
-    
+
     /**
      * City
      *
      * @var string
      */
     public $city;
-    
+
     /**
      * State
      *
      * @var string
      */
     public $state;
-    
+
     /**
      * zip code
      *
      * @var string
      */
     public $postal_code;
-    
+
     protected $_ldap;
 
     protected $_results;
-    
+
     /**
      * SimpleXMLElement of the HR Tree file
      *
@@ -80,9 +80,9 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      * @var string Prefix added to all xpath queries
      */
     protected static $_xpath_base = '//attribute[@name="org_unit"][@value="50000003"]/..';
-    
+
     public $options = array();
-    
+
     /**
      * construct a department
      *
@@ -105,13 +105,13 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
         $result = false;
 
         if (isset($options['xml'])) {
-            $result = $options['xml'];    
+            $result = $options['xml'];
         } elseif (isset($options['org_unit'])) {
             $result = self::getXMLById($options['org_unit']);
         } elseif (isset($options['d'])) {
             $result = self::getXMLByName($options['d']);
         }
-    
+
         if (!$result) {
             throw new Exception('Invalid department', 404);
         }
@@ -127,7 +127,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
             }
         }
     }
-    
+
     /**
      * Get the XML for the HR Tree
      *
@@ -140,7 +140,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
         }
         return self::$_xml;
     }
-    
+
     /**
      * Retrieves people records from the LDAP directory
      *
@@ -155,7 +155,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
         }
         return $this->_results;
     }
-    
+
     /**
      * returns the count of employees
      *
@@ -165,12 +165,12 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
     {
         return count($this->getLDAPResults());
     }
-    
+
     function rewind()
     {
         $this->getLDAPResults()->rewind();
     }
-    
+
     /**
      * Get the current record in the iteration
      *
@@ -180,28 +180,28 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
     {
         return $this->getLDAPResults()->current();
     }
-    
+
     function key()
     {
         return $this->getLDAPResults()->key();
     }
-    
+
     function next()
     {
         $this->getLDAPResults()->next();
     }
-    
+
     function valid()
     {
         return $this->getLDAPResults()->valid();
     }
-    
+
     function hasChildren()
     {
         $results = self::getXML()->xpath(self::$_xpath_base.'//attribute[@name="org_unit"][@value="'.$this->org_unit.'"]/../branch');
         return count($results)?true:false;
     }
-    
+
     function getChildren()
     {
         $children = array();
@@ -221,7 +221,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
 
     /**
      * Retrieve an official SAP Org entry by ID
-     * 
+     *
      * @param int $id ID, such as 5000XXXX
      */
     public static function getById($id, $options = array())

--- a/src/UNL/Peoplefinder/Department.php
+++ b/src/UNL/Peoplefinder/Department.php
@@ -65,8 +65,6 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      */
     public $postal_code;
 
-    protected $_ldap;
-
     protected $_results;
 
     /**
@@ -81,14 +79,14 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      */
     protected static $_xpath_base = '//attribute[@name="org_unit"][@value="50000003"]/..';
 
-    public $options = array();
+    public $options = [];
 
     /**
      * construct a department
      *
      * @param string $name Name of the department
      */
-    function __construct($options = array())
+    public function __construct($options = [])
     {
         if (!(
                 isset($options['d'])
@@ -146,7 +144,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      *
      * @return resource
      */
-    function getLDAPResults()
+    public function getLDAPResults()
     {
         if (!isset($this->_results)) {
             UNL_Peoplefinder::$resultLimit = 500;
@@ -161,12 +159,12 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      *
      * @return int
      */
-    function count()
+    public function count()
     {
         return count($this->getLDAPResults());
     }
 
-    function rewind()
+    public function rewind()
     {
         $this->getLDAPResults()->rewind();
     }
@@ -176,35 +174,35 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      *
      * @return UNL_Peoplefinder_Record
      */
-    function current()
+    public function current()
     {
         return $this->getLDAPResults()->current();
     }
 
-    function key()
+    public function key()
     {
         return $this->getLDAPResults()->key();
     }
 
-    function next()
+    public function next()
     {
         $this->getLDAPResults()->next();
     }
 
-    function valid()
+    public function valid()
     {
         return $this->getLDAPResults()->valid();
     }
 
-    function hasChildren()
+    public function hasChildren()
     {
         $results = self::getXML()->xpath(self::$_xpath_base.'//attribute[@name="org_unit"][@value="'.$this->org_unit.'"]/../branch');
         return count($results)?true:false;
     }
 
-    function getChildren()
+    public function getChildren()
     {
-        $children = array();
+        $children = [];
         $results = self::getXML()->xpath(self::$_xpath_base.'//attribute[@name="org_unit"][@value="'.$this->org_unit.'"]/../branch');
         foreach ($results as $result) {
             foreach ($result[0] as $attribute) {
@@ -224,7 +222,7 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
      *
      * @param int $id ID, such as 5000XXXX
      */
-    public static function getById($id, $options = array())
+    public static function getById($id, $options = [])
     {
         if ($result = self::getXMLById($id)) {
             $options['xml'] = $result;

--- a/src/UNL/Peoplefinder/Department.php
+++ b/src/UNL/Peoplefinder/Department.php
@@ -147,9 +147,10 @@ class UNL_Peoplefinder_Department implements Countable, Iterator
     public function getLDAPResults()
     {
         if (!isset($this->_results)) {
+            $prevResultLimit = UNL_Peoplefinder::$resultLimit;
             UNL_Peoplefinder::$resultLimit = 500;
-            $pf = new UNL_Peoplefinder($this->options);
-            $this->_results = $pf->getHROrgUnitNumberMatches($this->org_unit);
+            $this->_results = UNL_Peoplefinder::getInstance()->getHROrgUnitNumberMatches($this->org_unit);
+            UNL_Peoplefinder::$resultLimit = $prevResultLimit;
         }
         return $this->_results;
     }


### PR DESCRIPTION
Reuses a singleton `UNL_Peoplefinder` instance when fetching employees via HR number. Also uses faster query for selecting departments without child listings.