### PR TITLE
Add methods and script to cache all Faculty CV data

### DIFF
--- a/examples/cache_example.txt
+++ b/examples/cache_example.txt
@@ -1,0 +1,7 @@
+start memcached on your local machine
+be sure your UNL_Cache_Lite can write to tmp directory
+
+run `php scripts/cache_knowledge.php`
+telnet into memcached `telnet localhost 11211`
+in telnet, do `get lperez1` you should see data
+`quit` to exit

--- a/examples/cache_example.txt
+++ b/examples/cache_example.txt
@@ -3,5 +3,5 @@ be sure your UNL_Cache_Lite can write to tmp directory
 
 run `php scripts/cache_knowledge.php`
 telnet into memcached `telnet localhost 11211`
-in telnet, do `get lperez1` you should see data
+in telnet, do `get UNL_Directory_FacultyData_PUBLIC_WEB_lperez1` you should see data
 `quit` to exit

--- a/scripts/cache_knowledge.php
+++ b/scripts/cache_knowledge.php
@@ -1,0 +1,5 @@
+<?php
+require_once 'www/config.inc.php';
+
+$driver = new UNL_Knowledge_Driver_REST;
+$driver->getAllRecords();

--- a/src/UNL/Knowledge/Driver/REST.php
+++ b/src/UNL/Knowledge/Driver/REST.php
@@ -21,7 +21,7 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
 
     protected static $key_prefix = 'UNL_Directory_FacultyData_';
 
-    public static $cache_length = 14400; //default to 15 minutes, temporarily set at 4 hours to mitigate digital signage problems.
+    public static $cache_length = 1200; //default to 20 minutes
 
     public function __construct($options = array())
     {
@@ -57,7 +57,7 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
                 return $result;
             }
         } catch (Exception $e) {
-            error_log($e->message);
+            error_log($e);
         }
 
         # if that doesn't work, curl the API
@@ -77,6 +77,7 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
 
         $responseData = curl_exec($curl);
         $isAPIError = false;
+        $error_message = '';
 
         if (!curl_errno($curl)) {
             $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
@@ -90,8 +91,8 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
                 $result = null;
             }
         } else {
-            curl_error($curl);
-            error_log($errorMessage);
+            $error_message = curl_error($curl);
+            error_log($error_message);
             $isAPIError = true;
         }
 
@@ -108,9 +109,67 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
         try {
             $this->cache($key, $result);
         } catch (Exception $e) {
-            error_log($e->message);
+            error_log($e);
         }
         return $result;
+    }
+
+    protected function getCategoryForAll($category)
+    {
+        $full_result = array();
+
+        $curl = curl_init();
+
+        curl_setopt_array($curl, array(
+            CURLOPT_URL             => $this->service_url . $category,
+            CURLOPT_USERPWD         => UNL_Knowledge_Driver_REST::$service_user . ':' . UNL_Knowledge_Driver_REST::$service_pass,
+            CURLOPT_ENCODING        => 'gzip',
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_CONNECTTIMEOUT  => 5,
+            CURLOPT_TIMEOUT         => 5,
+        ));
+
+        $responseData = curl_exec($curl);
+        $isAPIError = false;
+        $error_message = '';
+
+        if (!curl_errno($curl)) {
+            $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+            if ($statusCode === 200) {
+                // type juggle XML to JSON
+                $array = json_decode(json_encode(simplexml_load_string($responseData, "SimpleXMLElement", LIBXML_NOCDATA)), true);
+                
+                # this query gives an array of records under teh "Record" key
+                foreach ($array['Record'] as $record) {
+                    $result = isset($record[$category]) ? $record[$category] : null;
+                    $key = self::$key_prefix . $category . '_' . $record['@attributes']['username'];
+                    try {
+                        $this->cache($key, $result);
+                    } catch (Exception $e) {
+                        error_log($e);
+                    }
+                    $full_result[] = $result;
+                }
+            } else {
+                // Server returns 500 errors for not found
+                $full_result = null;
+            }
+        } else {
+            $error_message = curl_error($curl);
+            error_log($error_message);
+            $isAPIError = true;
+        }
+
+        curl_close($curl);
+
+        if ($isAPIError) {
+            $full_result = 'ERROR: ' . $error_message ;
+            return $full_result;
+        }
+
+        return $full_result;
     }
 
     public function getRecords($uid)
@@ -129,6 +188,32 @@ class UNL_Knowledge_Driver_REST implements UNL_Knowledge_DriverInterface
         }
 
         return null;
+    }
+
+    public function getAllRecords()
+    {
+        $full_result = $this->getCategoryForAll('PUBLIC_WEB');
+
+        if (is_array($full_result)) {
+            $full_records = array();
+
+            foreach ($full_result as $data) {
+                $records = new UNL_Knowledge_Records();
+                foreach ($records->getRecordsMap() as $var => $dataKey) {
+                    if (isset($data[$dataKey])) {
+                        $records->$var = $this->cleanRecords($data[$dataKey]);
+                    }
+                }
+
+                $full_records[] = $records;
+            }
+
+            return $full_records;
+        } else if (is_string($full_result)) {
+            return $full_result;
+        }
+
+        return null;       
     }
 
     protected function cleanRecords($records)


### PR DESCRIPTION
Queries to Digital Measures were causing epic server load,
especially on digital signage where offices/departments
were being printed. Instead of getting this data on demand,
this commit adds a script which will be added to cron to
grab the data every 15 minutes from Digital Measures, and
cache it for fast retrieval on all queries.

This method can be tested by following the directions given
in examples/cache_example.txt .