### PR TITLE
Fix the display of names

### DIFF
--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -314,7 +314,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             return false;
         }
         
-        if ($this->eduPersonNickname != ' ') {
+        if ($this->eduPersonNickname == ' ') {
             return false;
         }
         

--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -310,7 +310,20 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
 
     public function hasNickname()
     {
-        return !empty($this->eduPersonNickname) && $this->eduPersonNickname != ' ';
+        if (empty($this->eduPersonNickname)) {
+            return false;
+        }
+        
+        if ($this->eduPersonNickname != ' ') {
+            return false;
+        }
+        
+        if ($this->eduPersonNickname == $this->cn) {
+            //Its the same as the common name :(
+            return false;
+        }
+        
+        return true;
     }
 
     /**


### PR DESCRIPTION
a recent update to LDAP now always give eduPersonNickname the same value as CN. This adjusts logic to account for that circumstance.