### PR TITLE
whitelist new affiliations

### DIFF
--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -100,7 +100,7 @@ class UNL_Peoplefinder
          //The following are the result of July 2017 LDAP changes, will be changed in the future.
          'administrative', 
          'faculty/executive',
-         't',
+         't', //Tenure
         );
 
     protected static $replacement_data = array();

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -97,6 +97,10 @@ class UNL_Peoplefinder
 //        'rif',
 //        'override',  // (will exist in guest ou)
 //        'sponsored', // (will exist in guest ou)
+         //The following are the result of July 2017 LDAP changes, will be changed in the future.
+         'administrative', 
+         'faculty/executive',
+         't',
         );
 
     protected static $replacement_data = array();


### PR DESCRIPTION
These are the result of recent LDAP changes, and are preventing some people from being displayed.