### PR TITLE
	Apply fixes to all data endpoints

### DIFF
--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -97,10 +97,6 @@ class UNL_Peoplefinder
 //        'rif',
 //        'override',  // (will exist in guest ou)
 //        'sponsored', // (will exist in guest ou)
-         //The following are the result of July 2017 LDAP changes, will be changed in the future.
-         'administrative', 
-         'faculty/executive',
-         't', //Tenure
         );
 
     protected static $replacement_data = array();

--- a/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
@@ -13,17 +13,17 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
         'faculty/executive' => 'faculty',
         'administrative' => 'staff',
     );
-    
-	public function __construct(array $entry)
-	{
-		$entry = self::normalizeEntry($entry);
-		parent::__construct($entry, ArrayObject::ARRAY_AS_PROPS);
-	}
 
-	protected static function normalizeEntry(array $entry)
-	{
-	    $entry = self::fix2017LdapChanges($entry);
-		$entry = UNL_Peoplefinder_Driver_LDAP_Util::filterArrayByKeys($entry, 'is_string');
+    public function __construct(array $entry)
+    {
+        $entry = self::normalizeEntry($entry);
+        parent::__construct($entry, ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    protected static function normalizeEntry(array $entry)
+    {
+        $entry = self::fix2017LdapChanges($entry);
+        $entry = UNL_Peoplefinder_Driver_LDAP_Util::filterArrayByKeys($entry, 'is_string');
         unset($entry['count']);
         foreach ($entry as $attribute => $value) {
             if (is_array($value)) {
@@ -33,7 +33,7 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
         }
 
         return $entry;
-	}
+    }
 
     /**
      * @param array $entry
@@ -42,18 +42,18 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
     protected static function fix2017LdapChanges(array $entry)
     {
         if (!isset($entry['uid'])) {
-            //This is likely an objecttype role entry, not a person.
+            //This is likely an objecttype=role entry, not a person.
             return $entry;
         }
 
         if (isset($entry['edupersonnickname']) && $entry['edupersonnickname'] == $entry['cn']) {
             $entry['edupersonnickname'] = null;
         }
-        
+
         if (!isset($entry['edupersonprimaryaffiliation'])) {
             //print_r($entry);exit();
         }
-        
+
         if (isset($entry['edupersonprimaryaffiliation'])) {
             //Some records appear to not have this attribute.
             foreach ($entry['edupersonprimaryaffiliation'] as $key => $value) {
@@ -79,7 +79,7 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
                 }
             }
         }
-        
+
         if (isset($entry['edupersonaffiliation'])) {
             //Some records appear to not have this attribute.
             foreach ($entry['edupersonaffiliation'] as $key => $value) {
@@ -108,38 +108,38 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
         return $entry;
     }
 
-	public function append($value)
-	{
-		throw new Exception('Unimplemented');
-	}
+    public function append($value)
+    {
+        throw new Exception('Unimplemented');
+    }
 
-	public function exchangeArray($input)
-	{
-		$input = self::normalizeEntry($input);
-		return parent::exchangeArray($input);
-	}
+    public function exchangeArray($input)
+    {
+        $input = self::normalizeEntry($input);
+        return parent::exchangeArray($input);
+    }
 
-	public function offsetExists($index)
-	{
-		$index = strtolower($index);
-		return parent::offsetExists($index);
-	}
+    public function offsetExists($index)
+    {
+        $index = strtolower($index);
+        return parent::offsetExists($index);
+    }
 
-	public function offsetGet($index)
-	{
-		$index = strtolower($index);
-		return parent::offsetGet($index);
-	}
+    public function offsetGet($index)
+    {
+        $index = strtolower($index);
+        return parent::offsetGet($index);
+    }
 
-	public function offsetSet($index, $newval)
-	{
-		$index = strtolower($index);
-		return parent::offsetSet($index, $newval);
-	}
+    public function offsetSet($index, $newval)
+    {
+        $index = strtolower($index);
+        return parent::offsetSet($index, $newval);
+    }
 
-	public function offsetUnset($index)
-	{
-		$index = strtolower($index);
-		return parent::offsetUnset($index);
-	}
+    public function offsetUnset($index)
+    {
+        $index = strtolower($index);
+        return parent::offsetUnset($index);
+    }
 }

--- a/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
@@ -50,10 +50,6 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
             $entry['edupersonnickname'] = null;
         }
 
-        if (!isset($entry['edupersonprimaryaffiliation'])) {
-            //print_r($entry);exit();
-        }
-
         if (isset($entry['edupersonprimaryaffiliation'])) {
             //Some records appear to not have this attribute.
             foreach ($entry['edupersonprimaryaffiliation'] as $key => $value) {

--- a/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
@@ -71,7 +71,7 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
                     unset($entry['edupersonprimaryaffiliation'][$key]);
                 } else {
                     //Change the affiliation
-                    $entry['edupersonprimaryaffiliation'][$key] = self::$affiliationMapping[$value];
+                    $entry['edupersonprimaryaffiliation'][$key] = $newValue;
                 }
             }
         }
@@ -96,7 +96,7 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
                     unset($entry['edupersonaffiliation'][$key]);
                 } else {
                     //Change the affiliation
-                    $entry['edupersonaffiliation'][$key] = self::$affiliationMapping[$value];
+                    $entry['edupersonaffiliation'][$key] = $newValue;
                 }
             }
         }

--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -323,11 +323,6 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             return false;
         }
         
-        if ($this->eduPersonNickname == $this->cn) {
-            //Its the same as the common name :(
-            return false;
-        }
-        
         return true;
     }
 


### PR DESCRIPTION
Logic was just being applied to some endpoints and representations. This corrects several of the issues in the LDAP record itself before it is used anywhere else. For example, JSON endpoints should now match the expected values.