### PR TITLE
fix the qr code link

### DIFF
--- a/www/js/directory.js
+++ b/www/js/directory.js
@@ -487,7 +487,9 @@ define([
 		});
 
 		$container.on('click', '.icon-qr-code', function() {
-			var self = this;
+			//Grab the closest 'a' element, because a child of the a element likely triggered this event.
+			var self = $(this).closest('a');
+			
 			var onReady = function() {
 				modalReady = true;
 				$(self).colorbox({open:true, photo:true});


### PR DESCRIPTION
In some cases, the modal would load with an error because it tried to load based on the target element. That is fine as long as the target element is the `<a href>`, but that isn't the case here. So when the container is clicked, grab the closest `a` element.