### PR TITLE
remove the help link by the search bar

### DIFF
--- a/www/templates/html/Peoplefinder/StandardForm.tpl.php
+++ b/www/templates/html/Peoplefinder/StandardForm.tpl.php
@@ -16,7 +16,6 @@
         </span>
     </div>
 </form>
-<p class="wdn-sans-serif"><a href="<?php echo UNL_Peoplefinder::getURL() ?>help/">Help</a></p>
 
 <?php echo $savvy->render((object) [
     'id' => 'noticeTemplate',


### PR DESCRIPTION
It is already in the footer and isn't used that often anyway. 