### PR TITLE
Display the full building name

### DIFF
--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -210,7 +210,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
         }
 
         // check for a building code + room number
-        if (isset($streetParts[1], $bldgs[$streetParts[1]], $bldgs[$streetParts[0]])) {
+        if (isset($streetParts[1], $bldgs[strtoupper($streetParts[1])], $bldgs[strtoupper($streetParts[0])])) {
             // oh no, both are building codes! check if one is strictly numeric
             // if so, assume that is the room number
             if (preg_match('/^[\d]*$/', $streetParts[0]) && !preg_match('/^[\d]*$/', $streetParts[1])) {
@@ -224,12 +224,12 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
                     $address['roomNumber'] = $streetParts[1];
                 }
             }
-        } else if (isset($bldgs[$streetParts[0]])) {
+        } else if (isset($bldgs[strtoupper($streetParts[0])])) {
             $address['unlBuildingCode'] = $streetParts[0];
             if (isset($streetParts[1])) {
                 $address['roomNumber'] = $streetParts[1];
             }
-        } else if (isset($streetParts[1], $bldgs[$streetParts[1]])) {
+        } else if (isset($streetParts[1], $bldgs[strtoupper($streetParts[1])])) {
             // legacy format (room number first)
             $address['unlBuildingCode'] = $streetParts[1];
             $address['roomNumber'] = $streetParts[0];
@@ -251,6 +251,11 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
                  
                  $address['postal-code'] = $part;
             }
+        }
+        
+        //find the building name
+        if (isset($address['unlBuildingCode']) && isset($bldgs[strtoupper($address['unlBuildingCode'])])) {
+            $address['unlBuildingName'] = $bldgs[strtoupper($address['unlBuildingCode'])];
         }
 
         // next from the end should be locality

--- a/tests/PeoplefinderRecordTest.php
+++ b/tests/PeoplefinderRecordTest.php
@@ -32,6 +32,7 @@ class PeoplefinderRecordTest extends \PHPUnit\Framework\TestCase {
             'region' => 'NE',
             'postal-code' => '68588-0429',
             'unlBuildingCode' => 'ADMS',
+            'unlBuildingName' => 'Canfield Administration Building South',
             'roomNumber' => '313'
         ), $formatted);
     }
@@ -47,6 +48,7 @@ class PeoplefinderRecordTest extends \PHPUnit\Framework\TestCase {
             'region' => 'NE',
             'postal-code' => '68588-0429',
             'unlBuildingCode' => 'ADMS',
+            'unlBuildingName' => 'Canfield Administration Building South',
             'roomNumber' => '313'
         ), $formatted);
     }
@@ -62,6 +64,7 @@ class PeoplefinderRecordTest extends \PHPUnit\Framework\TestCase {
             'region' => 'NE',
             'postal-code' => '68588-0429',
             'unlBuildingCode' => 'AVH',
+            'unlBuildingName' => 'Avery Hall',
             'roomNumber' => '420'
         ), $formatted);
     }
@@ -78,6 +81,7 @@ class PeoplefinderRecordTest extends \PHPUnit\Framework\TestCase {
             'region' => 'NE',
             'postal-code' => '68588-0429',
             'unlBuildingCode' => '420',
+            'unlBuildingName' => '420 University Terrace',
             'roomNumber' => '501'
         ), $formatted);
     }
@@ -105,7 +109,8 @@ class PeoplefinderRecordTest extends \PHPUnit\Framework\TestCase {
             'locality' => 'Lincoln',
             'region' => 'NE',
             'postal-code' => '68588-0634',
-            'unlBuildingCode' => '17PG'
+            'unlBuildingCode' => '17PG',
+            'unlBuildingName' => '17th and R Parking Garage',
         ), $formatted);
         $this->assertFalse(array_key_exists('roomNumber', $formatted));
     }

--- a/www/templates/html/Peoplefinder/Record.tpl.php
+++ b/www/templates/html/Peoplefinder/Record.tpl.php
@@ -124,7 +124,12 @@ $showKnowledge = $context->shouldShowKnowledge();
             <span class="type">Work</span>
             <?php if (!empty($address['unlBuildingCode'])): ?>
                 <span class="street-address">
-                    <a href="https://maps.unl.edu/<?php echo $address['unlBuildingCode'] ?>" itemprop="hasMap"><?php echo $address['unlBuildingCode'] ?></a>
+                    <?php if (isset($address['unlBuildingName'])) : ?>
+                        <a href="https://maps.unl.edu/<?php echo strtoupper($address['unlBuildingCode']) ?>" itemprop="hasMap"><?php echo $address['unlBuildingName'] ?></a> (<?php echo $address['unlBuildingCode'] ?>)
+                    <?php else: ?>
+                        <a href="https://maps.unl.edu/<?php echo strtoupper($address['unlBuildingCode']) ?>" itemprop="hasMap"><?php echo $address['unlBuildingCode'] ?></a>
+                    <?php endif; ?>
+                    
                     <?php echo str_replace($address['unlBuildingCode'], '', $address['street-address']) ?>
                 </span>
             <?php endif; ?>


### PR DESCRIPTION
This converts the way that the building is identified in the address from

```
[unlBuildingCode] [number]
```

to

```
[unlBuildingName] ([unlBuildingCode]) [number]
```

It also adds logic to always converts the building code string to uppercase when comparing to building lists (which expects all caps).