### PR TITLE
Allow the display of central appointments

### DIFF
--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -76,7 +76,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
 
     public function getRoles($uid)
     {
-        $results = $this->query("SELECT * FROM unl_appointments appointments, unl_biodemo biodemo WHERE
+        $results = $this->query("SELECT * FROM unl_appointments_listed_unca appointments, unl_biodemo biodemo WHERE
             biodemo.biodemo_id = appointments.biodemo_id 
             AND biodemo.netid = :user_identification_string 
             AND appointments.end_date >= '" . date('Y-m-d') . "'", 
@@ -116,7 +116,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
 
     public function getHROrgUnitNumberMatches($query, $affiliation = null)
     {
-        $results = $this->query("SELECT DISTINCT biodemo.netid FROM unl_appointments appointments, unl_biodemo biodemo WHERE
+        $results = $this->query("SELECT DISTINCT biodemo.netid FROM unl_appointments_listed_unca appointments, unl_biodemo biodemo WHERE
             biodemo.biodemo_id = appointments.biodemo_id 
             AND appointments.org_unit = :org_unit
             AND appointments.end_date >= '" . date('Y-m-d') . "'", 
@@ -144,7 +144,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
             $binding_array[$key] = $query[$i];
         }
 
-        $results = $this->query("SELECT DISTINCT biodemo.netid FROM unl_appointments appointments, unl_biodemo biodemo WHERE
+        $results = $this->query("SELECT DISTINCT biodemo.netid FROM unl_appointments_listed_unca appointments, unl_biodemo biodemo WHERE
             biodemo.biodemo_id = appointments.biodemo_id 
             AND appointments.org_unit IN (" . implode(', ', $binding_list) . ")
             AND appointments.end_date >= '" . date('Y-m-d') . "'", 

--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -362,6 +362,39 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
         return implode(', ', $affiliations);
     }
 
+    /**
+     * Determine if this person has an affiliation that is likely to contain an appointment
+     * This is mostly done to reduce the number of database queries (and might not be needed)
+     * 
+     * @return bool
+     */
+    public function affiliationMightIncludeAppointments()
+    {
+        if (!$this->eduPersonAffiliation) {
+            return false;
+        }
+        
+        $affiliationsWithAppointments = [
+            'staff',
+            'faculty',
+            'volunteer',
+            'affiliate'
+        ];
+
+        $affiliations = $this->eduPersonAffiliation;
+        if ($affiliations instanceof ArrayIterator) {
+            $affiliations = $affiliations->getArrayCopy();
+        }
+        
+        foreach ($affiliationsWithAppointments as $affiliation) {
+            if (in_array($affiliation, $affiliations)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
     public function formatTitle()
     {
         if (!$this->title) {

--- a/www/templates/html/Peoplefinder/Record.tpl.php
+++ b/www/templates/html/Peoplefinder/Record.tpl.php
@@ -71,7 +71,7 @@ $showKnowledge = $context->shouldShowKnowledge();
         <div class="eppa">(<?php echo $affiliations ?>)</div>
     <?php endif; ?>
 
-    <?php if (isset($context->unlHROrgUnitNumber)): ?>
+    <?php if ($context->affiliationMightIncludeAppointments()): ?>
         <?php
         $roles = $context->getRoles();
         $title = $context->formatTitle();


### PR DESCRIPTION
* updates queries to reference a database view that contains central appointments
* people with central appointments will not have a primary HR department defined in AD, so adjust logic to account for that
* The appointments will not be displayed until the new ITS org units are manually entered into the officefinder database