### PR TITLE
Add a test user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /data/suppress_uids.txt
 /data/hr_tree.xml
 /data/faculty_education.csv
+/data/test-data.inc.php
 /data/unl_sis_bio.txt
 /data/unl_sis_prog.txt
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ php scripts/import_sis_data.php
 
 Note: this needs to be ran at least once a day to keep the data in the cache
 
+## Sample User (Optional)
+
+The idea is to simulate a person record that doesn't exist in the official identity system.
+
+Reasons to do this:
+- So there is a permanent person (that won't quit or retire) for another system to use for testing.
+- As a test/development record for possible schema changes or to see how different data affects output.
+- As an Easter egg.
+
+To enable and use the sample user:
+To use:
+1) Copy /data/test-data.inc_sample.php to /data/test-data.inc.php and edit if desired.
+2) Make sure the include of /data/test-data.inc.php and the setting of UNL_Peoplefinder::$sampleUID are uncommented in config.inc.php
+
+
 ## INSTALL
 
 1) Run: 'npm install; grunt; composer install'

--- a/data/test-data.inc.php
+++ b/data/test-data.inc.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Sample of the result of the query in UNL_Peoplefinder_Driver_OracleDB->fixLDAPEntries()
+ * Simulates the result for one person: hhusker1
+ */
+UNL_Peoplefinder_Driver_OracleDB::$sampleFixLDAPEntries =
+array (
+    0 =>
+        array (
+            'NETID' => 'hhusker1',
+            'NU_FERPA' => NULL,
+            'MAIL' => 'NOREPLY@UNL.EDU',
+        ),
+);
+
+
+/**
+ * Sample of the result of ldap_get_entries().
+ * Simulates a result for one person: hhusker1
+ */
+UNL_Peoplefinder_Driver_LDAP::$samplePersonLDAP =
+array (
+    'count' => 1,
+    0 =>
+        array (
+            'cn' =>
+                array (
+                    'count' => 1,
+                    0 => 'hhusker1',
+                ),
+            0 => 'cn',
+            'sn' =>
+                array (
+                    'count' => 1,
+                    0 => 'Husker',
+                ),
+            1 => 'sn',
+            'title' =>
+                array (
+                    'count' => 1,
+                    0 => 'Mascot',
+                ),
+            2 => 'title',
+            'postaladdress' =>
+                array (
+                    'count' => 1,
+                    0 => 'MSTD, UNL, 685880120',
+                ),
+            3 => 'postaladdress',
+            'telephonenumber' =>
+                array (
+                    'count' => 1,
+                    0 => '4024724224',
+                ),
+            4 => 'telephonenumber',
+            'givenname' =>
+                array (
+                    'count' => 1,
+                    0 => 'Herbie',
+                ),
+            5 => 'givenname',
+            'displayname' =>
+                array (
+                    'count' => 1,
+                    0 => 'Herbie Husker',
+                ),
+            6 => 'displayname',
+            'department' =>
+                array (
+                    'count' => 1,
+                    0 => 'Athletics                            UNL',
+                ),
+            7 => 'department',
+            'samaccountname' =>
+                array (
+                    'count' => 1,
+                    0 => 'hhusker1',
+                ),
+            8 => 'samaccountname',
+            'mail' =>
+                array (
+                    'count' => 1,
+                    0 => 'hhusker1@unl.edu',
+                ),
+            9 => 'mail',
+            'departmentnumber' =>
+                array (
+                    'count' => 1,
+                    0 => '50000850',
+                ),
+            10 => 'departmentnumber',
+            'edupersonprincipalname' =>
+                array (
+                    'count' => 1,
+                    0 => 'hhusker1@unl.edu',
+                ),
+            11 => 'edupersonprincipalname',
+            'edupersonaffiliation' =>
+                array (
+                    'count' => 3,
+                    0 => 'student',
+                    1 => 'enrolled',
+                    2 => 'staff',
+                ),
+            12 => 'edupersonaffiliation',
+            'edupersonprimaryaffiliation' =>
+                array (
+                    'count' => 1,
+                    0 => 'staff',
+                ),
+            13 => 'edupersonprimaryaffiliation',
+            'unluncwid' =>
+                array (
+                    'count' => 1,
+                    0 => '01234567',
+                ),
+            14 => 'unluncwid',
+            'count' => 15,
+            'dn' => 'CN=hhusker1,OU=people,DC=unl,DC=edu',
+        ),
+);

--- a/data/test-data.inc_sample.php
+++ b/data/test-data.inc_sample.php
@@ -1,6 +1,12 @@
 <?php
 
 /**
+ * To use:
+ * Copy this file to /data/test-data.inc.php
+ * Make sure the lines related to this file and UNL_Peoplefinder::$sampleUID are uncommented in config.inc.php
+ */
+
+/**
  * Sample of the result of the query in UNL_Peoplefinder_Driver_OracleDB->fixLDAPEntries()
  * Simulates the result for one person: hhusker1
  */

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -40,6 +40,8 @@ class UNL_Peoplefinder
 
     static public $testDomains = array('directory-test.unl.edu');
 
+    static public $sampleUID;
+
     static protected $instance;
 
     /**

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -107,6 +107,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     public $lastQuery;
     public $lastResult;
 
+    /** Sample Data Set in Config File */
+    public static $samplePersonLDAP;
+
     public function __construct()
     {
     }
@@ -405,11 +408,17 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
      */
     public function getUID($uid)
     {
-        $filter = new UNL_Peoplefinder_Driver_LDAP_UIDFilter($uid);
-        $r = $this->query($filter->__toString(), $this->detailAttributes, false);
+        if ($uid == UNL_Peoplefinder::$sampleUID) {
+            $r = self::normalizeLdapEntries(self::$samplePersonLDAP);
+        } else {
+            $filter = new UNL_Peoplefinder_Driver_LDAP_UIDFilter($uid);
+            $r = $this->query($filter->__toString(), $this->detailAttributes, false);
+        }
+
         if (empty($r)) {
             throw new Exception('Cannot find that UID.', 404);
         }
+
         return self::recordFromLDAPEntry(current($r));
     }
 

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -316,12 +316,22 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
      */
     public function getExactMatches($query, $affiliation = null)
     {
-        if ($affiliation) {
-            $filter = new UNL_Peoplefinder_Driver_LDAP_AffiliationFilter($query, $affiliation, '&', false);
-        } else {
-            $filter = new UNL_Peoplefinder_Driver_LDAP_StandardFilter($query, '&', false);
+        // Load the Sample User so a string comparison to their name can be done.
+        if (isset(UNL_Peoplefinder::$sampleUID)) {
+            $result = self::normalizeLdapEntries(self::$samplePersonLDAP);
+            $sampleRecord = self::recordFromLDAPEntry(current($result));
+            $this->lastResult = $result;
         }
-        $this->query($filter->__toString(), $this->detailAttributes);
+
+        // If the query doesn't exactly match the Sample User's Display Name then run the query.
+        if (!isset($sampleRecord) || $query !== (string)$sampleRecord->displayName) {
+            if ($affiliation) {
+                $filter = new UNL_Peoplefinder_Driver_LDAP_AffiliationFilter($query, $affiliation, '&', false);
+            } else {
+                $filter = new UNL_Peoplefinder_Driver_LDAP_StandardFilter($query, '&', false);
+            }
+            $this->query($filter->__toString(), $this->detailAttributes);
+        }
         return $this->getRecordsFromResults();
     }
 

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -12,6 +12,9 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
 
     private $conn;
 
+    /** Sample Data Set in Config File */
+    public static $sampleFixLDAPEntries;
+
     private function connect() 
     {
         $connec = oci_connect(self::$connection_username, self::$connection_password, 
@@ -223,14 +226,18 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
             $binding_array[$key] = $entry['uid'][0];
             $i++;
         }
-        
-        // UNL_EMAILS_00.TYPE = 'USERINFO' is the work email address that we want
-        $query = "SELECT UNL_BIODEMO.NETID, UNL_BIODEMO.NU_FERPA, UNL_EMAILS_00.EMAIL as mail
+
+        if (count($uids) == 1 && isset($uids[UNL_Peoplefinder::$sampleUID])) {
+            $results = self::$sampleFixLDAPEntries;
+        } else {
+            // UNL_EMAILS_00.TYPE = 'USERINFO' is the work email address that we want
+            $query = "SELECT UNL_BIODEMO.NETID, UNL_BIODEMO.NU_FERPA, UNL_EMAILS_00.EMAIL as mail
             FROM UNL_BIODEMO
             LEFT JOIN UNL_EMAILS_00 ON UNL_BIODEMO.BIODEMO_ID = UNL_EMAILS_00.BIODEMO_ID AND UNL_EMAILS_00.TYPE = 'USERINFO'
             WHERE UNL_BIODEMO.NETID IN (" . implode(', ', $binding_list) . ")";
 
-        $results = $this->query($query, $binding_array);
+            $results = $this->query($query, $binding_array);
+        }
         
         // Now stitch everything back together
         foreach ($results as $row) {

--- a/www/config-sample.inc.php
+++ b/www/config-sample.inc.php
@@ -44,3 +44,7 @@ UNL_Peoplefinder_Driver_OracleDB::$connection_service = "SAPTPRD";
 
 // Test domains used in Peoplefinder.tpl.php
 UNL_Peoplefinder::$testDomains = array('directory-test.unl.edu', 'localhost');
+
+// Sample user ID
+UNL_Peoplefinder::$sampleUID = 'hhusker1';
+include_once __DIR__ . '/../data/test-data.inc.php';

--- a/www/config-sample.inc.php
+++ b/www/config-sample.inc.php
@@ -46,5 +46,5 @@ UNL_Peoplefinder_Driver_OracleDB::$connection_service = "SAPTPRD";
 UNL_Peoplefinder::$testDomains = array('directory-test.unl.edu', 'localhost');
 
 // Sample user ID
-UNL_Peoplefinder::$sampleUID = 'hhusker1';
-include_once __DIR__ . '/../data/test-data.inc.php';
+//UNL_Peoplefinder::$sampleUID = 'hhusker1';
+//include_once __DIR__ . '/../data/test-data.inc.php';


### PR DESCRIPTION
Closes #143 

The idea is to simulate a person record that doesn't exist in the official identity system.

Reasons to do this:
- So there is a permanent user (that won't quit or retire or be removed by IAM) for another system to use for testing. See https://github.com/unlcms/unl_user/pull/3
- As a test record for possible schema changes or to see how different data affects output.
- As an Easter egg. Right now we prompt people on the homepage to search for "Herbie Husker" but that doesn't return a result.

It is coded to be able to be enabled/disabled and customized per environment.  My plan is to deploy as-is with an exposed "hhusker1" sample person.

Deployed to test:
https://directory-test.unl - edu/#q/Herbie%20Husker
https://directory-test.unl - edu/people/hhusker1