### PR TITLE
Remove duplicate affiliations from search results

### DIFF
--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -365,7 +365,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             $affiliations = $affiliations->getArrayCopy();
         }
 
-        $affiliations = array_intersect(UNL_Peoplefinder::$displayedAffiliations, $affiliations);
+        $affiliations = array_intersect(UNL_Peoplefinder::$displayedAffiliations, array_unique($affiliations));
 
         return implode(', ', $affiliations);
     }

--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -365,7 +365,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             $affiliations = $affiliations->getArrayCopy();
         }
 
-        $affiliations = array_intersect(UNL_Peoplefinder::$displayedAffiliations, array_unique($affiliations));
+        $affiliations = array_intersect(UNL_Peoplefinder::$displayedAffiliations, $affiliations);
 
         return implode(', ', $affiliations);
     }

--- a/src/UNL/Peoplefinder/SearchResults.php
+++ b/src/UNL/Peoplefinder/SearchResults.php
@@ -24,10 +24,7 @@ class UNL_Peoplefinder_SearchResults extends ArrayIterator
 
         foreach ($results as $record) {
             if (isset($record->eduPersonAffiliation)) {
-                $affiliations = $record->eduPersonAffiliation;
-                if ($affiliations instanceof ArrayIterator) {
-                    $affiliations = $affiliations->getArrayCopy();
-                }
+                $affiliations = static::affiliationsToArray($record->eduPersonAffiliation);
                 foreach (array_unique($affiliations) as $affiliation) {
                     if (!in_array($affiliation, UNL_Peoplefinder::$displayedAffiliations)) {
                         // This is an affiliation we do not want displayed
@@ -41,6 +38,13 @@ class UNL_Peoplefinder_SearchResults extends ArrayIterator
             }
         }
         return $by_affiliation;
+    }
+
+    public static function affiliationsToArray($affiliations) {
+        if ($affiliations instanceof ArrayIterator) {
+            $affiliations = $affiliations->getArrayCopy();
+        }
+        return $affiliations;
     }
 
     public static function affiliationSort($affiliation1, $affiliation2)

--- a/src/UNL/Peoplefinder/SearchResults.php
+++ b/src/UNL/Peoplefinder/SearchResults.php
@@ -24,7 +24,11 @@ class UNL_Peoplefinder_SearchResults extends ArrayIterator
 
         foreach ($results as $record) {
             if (isset($record->eduPersonAffiliation)) {
-                foreach ($record->eduPersonAffiliation as $affiliation) {
+                $affiliations = $record->eduPersonAffiliation;
+                if ($affiliations instanceof ArrayIterator) {
+                    $affiliations = $affiliations->getArrayCopy();
+                }
+                foreach (array_unique($affiliations) as $affiliation) {
                     if (!in_array($affiliation, UNL_Peoplefinder::$displayedAffiliations)) {
                         // This is an affiliation we do not want displayed
                         continue;


### PR DESCRIPTION
Fix issue where some users have multiple `staff` affiliations which result in multiple search results.

You can test on https://directory-test.unl.edu/#q/alan%20nelson  and verify only one Alan Nelson record displays in results.

Contrast to production, https://directory.unl.edu/#q/alan%20nelson where multiple records display.
