### PR TITLE
Implement cache prime for department personnel tree

### DIFF
--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -3,9 +3,11 @@ require_once __DIR__.'/../www/config.inc.php';
 
 // Departments to cache personnel
 $deptOrgUnits = array(
+	50000955,
 	50000907,
 	50000897,
-	50000955,
+	50000905,
+	50000928,
 	50001078,
 	50000834,
 	50000908,
@@ -13,10 +15,8 @@ $deptOrgUnits = array(
 	50007300,
 	50001088,
 	50000899,
-	50000928,
 	50000828,
-	50000829,
-	50000905
+	50000829
 );
 
 foreach ($deptOrgUnits as $orgUnit) {

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -1,6 +1,11 @@
 <?php
 require_once __DIR__.'/../www/config.inc.php';
 
+$baseURL = isset($argv) && !empty($argv[1]) ? $argv[1] : '';
+if (empty($baseURL)) {
+	die('Missing baseurl arg.  i.e. > php cache_department_personnel.php https://directory.unl.edu');
+}
+
 // Departments to cache personnel
 $deptOrgUnits = array(
 	50000955,
@@ -22,7 +27,7 @@ $deptOrgUnits = array(
 foreach ($deptOrgUnits as $orgUnit) {
 	$start = time();
 	echo $orgUnit . " started at " . date("h:i:sa", $start) . "\n";
-	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
+	$url = $baseURL . '/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
 

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -21,7 +21,7 @@ $deptOrgUnits = array(
 
 foreach ($deptOrgUnits as $orgUnit) {
 	$start = time();
-	echo $orgUnit . " started at " . date("h:i:s", $start) . "\n";
+	echo $orgUnit . " started at " . date("h:i:sa", $start) . "\n";
 	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
@@ -35,5 +35,5 @@ foreach ($deptOrgUnits as $orgUnit) {
 	curl_close($ch);
 	$end = time();
 	$duration = ($end - $start) / 60;
-	echo $orgUnit . " finished at " . date("h:i:s", $end) . "took " . $duration . "minutes\n";
+	echo $orgUnit . " finished at " . date("h:i:sa", $end) . " took " . round($duration, 3) . " minutes\n\n";
 }

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -20,6 +20,8 @@ $deptOrgUnits = array(
 );
 
 foreach ($deptOrgUnits as $orgUnit) {
+	$start = time();
+	echo $orgUnit . " started at " . date("h:i:s", $start) . "\n";
 	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
@@ -31,4 +33,7 @@ foreach ($deptOrgUnits as $orgUnit) {
 
 	$lines_string = curl_exec($ch);
 	curl_close($ch);
+	$end = time();
+	$duration = ($end - $start) / 60;
+	echo $orgUnit . " finished at " . date("h:i:s", $end) . "took " . $duration . "minutes\n";
 }

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -24,6 +24,7 @@ $deptOrgUnits = array(
 	50000829
 );
 
+echo "\n\nProcessing org unit " . $baseURL . "/personnelsubstree pages with reset cache\n";
 foreach ($deptOrgUnits as $orgUnit) {
 	$start = time();
 	echo $orgUnit . " started at " . date("h:i:sa", $start) . "\n";

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -22,7 +22,7 @@ $deptOrgUnits = array(
 echo time() . "\n\n";
 foreach ($deptOrgUnits as $orgUnit) {
 	echo "Start " . $orgUnit . ' at ' . time() . "\n";
-	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&nocache=1';
+	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
 

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__.'/../www/config.inc.php';
+
+// Departments to cache personnel
+$deptOrgUnits = array(
+	50000907,
+	50000897,
+	50000955,
+	50001078,
+	50000834,
+	50000908,
+	50001081,
+	50007300,
+	50001088,
+	50000899,
+	50000928,
+	50000828,
+	50000829,
+	50000905
+);
+
+echo time() . "\n\n";
+foreach ($deptOrgUnits as $orgUnit) {
+	echo "Start " . $orgUnit . ' at ' . time() . "\n";
+	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&nocache=1';
+	$ch = curl_init();
+	$timeout = 400;
+
+	curl_setopt($ch, CURLOPT_URL, $url);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+	curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+
+	$lines_string = curl_exec($ch);
+	echo !empty($lines_string) ? "successful curl\n" : "failed curl\n";;
+	curl_close($ch);
+	echo 'End ' . $orgUnit . ' at ' . time() . "\n\n";
+}
+echo time() . "\n";

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -27,7 +27,7 @@ $deptOrgUnits = array(
 echo "\n\nProcessing org unit " . $baseURL . "/personnelsubstree pages with reset cache\n";
 foreach ($deptOrgUnits as $orgUnit) {
 	$start = time();
-	echo $orgUnit . " started at " . date("h:i:sa", $start) . "\n";
+	echo $orgUnit . " started at " . date("h:i:s a", $start) . "\n";
 	$url = $baseURL . '/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
@@ -41,5 +41,5 @@ foreach ($deptOrgUnits as $orgUnit) {
 	curl_close($ch);
 	$end = time();
 	$duration = ($end - $start) / 60;
-	echo $orgUnit . " finished at " . date("h:i:sa", $end) . " took " . round($duration, 3) . " minutes\n\n";
+	echo $orgUnit . " finished at " . date("h:i:s a", $end) . " took " . round($duration, 3) . " minutes\n\n";
 }

--- a/scripts/cache_department_personnel.php
+++ b/scripts/cache_department_personnel.php
@@ -19,9 +19,7 @@ $deptOrgUnits = array(
 	50000905
 );
 
-echo time() . "\n\n";
 foreach ($deptOrgUnits as $orgUnit) {
-	echo "Start " . $orgUnit . ' at ' . time() . "\n";
 	$url = 'https://directory-test.unl.edu/departments/' . $orgUnit . '/personnelsubtree?format=xml&reset-cache';
 	$ch = curl_init();
 	$timeout = 400;
@@ -32,8 +30,5 @@ foreach ($deptOrgUnits as $orgUnit) {
 	curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
 	$lines_string = curl_exec($ch);
-	echo !empty($lines_string) ? "successful curl\n" : "failed curl\n";;
 	curl_close($ch);
-	echo 'End ' . $orgUnit . ' at ' . time() . "\n\n";
 }
-echo time() . "\n";

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -26,21 +26,21 @@
  */
 class UNL_Peoplefinder
 {
-    static public $resultLimit = 250;
+    public static $resultLimit = 250;
 
-    static public $url = '';
+    public static $url = '';
 
-    static public $annotateUrl = 'http://annotate.unl.edu/';
+    public static $annotateUrl = 'http://annotate.unl.edu/';
 
-    static public $staticFileVersion = '4.1';
+    public static $staticFileVersion = '4.1';
 
-    static public $minifyHtml = true;
+    public static $minifyHtml = true;
 
-    static public $use_oracle = TRUE;
+    public static $use_oracle = TRUE;
 
-    static public $testDomains = array('directory-test.unl.edu');
+    public static $testDomains = array('directory-test.unl.edu');
 
-    static public $sampleUID;
+    public static $sampleUID;
 
     static protected $instance;
 
@@ -125,9 +125,12 @@ class UNL_Peoplefinder
         $this->driver = $options['driver'];
         $this->oracle_driver = new UNL_Peoplefinder_Driver_OracleDB();
 
-        if (isset($options['reset-cache']) && $this->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
-            $this->driver::$checkCache = FALSE;
-            $this->driver::$cacheTimeout = 86400; // cache for one day
+        if (isset($options['reset-cache'])) {
+            $this->oracle_driver::$resetCache = TRUE;
+            if ($this->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
+                $this->driver::$resetCache = TRUE;
+                $this->driver::$cacheTimeout = 86400; // cache for one day
+            }
         }
 
         $this->options = $options + $this->options;

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -125,6 +125,11 @@ class UNL_Peoplefinder
         $this->driver = $options['driver'];
         $this->oracle_driver = new UNL_Peoplefinder_Driver_OracleDB();
 
+        if (isset($options['reset-cache']) && $this->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
+            $this->driver::$checkCache = FALSE;
+            $this->driver::$cacheTimeout = 86400; // cache for one day
+        }
+
         $this->options = $options + $this->options;
 
         try {

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -129,7 +129,6 @@ class UNL_Peoplefinder
             $this->oracle_driver->resetCache();
             if ($this->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
                 $this->driver->resetCache();
-                $this->driver::$cacheTimeout = 86400; // cache for one day
             }
         }
 

--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -126,9 +126,9 @@ class UNL_Peoplefinder
         $this->oracle_driver = new UNL_Peoplefinder_Driver_OracleDB();
 
         if (isset($options['reset-cache'])) {
-            $this->oracle_driver::$resetCache = TRUE;
+            $this->oracle_driver->resetCache();
             if ($this->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
-                $this->driver::$resetCache = TRUE;
+                $this->driver->resetCache();
                 $this->driver::$cacheTimeout = 86400; // cache for one day
             }
         }

--- a/src/UNL/Peoplefinder/Cache.php
+++ b/src/UNL/Peoplefinder/Cache.php
@@ -108,6 +108,7 @@ class UNL_Peoplefinder_Cache
 	public function remove($key)
 	{
 		$this->fastCache->delete($key);
+		$this->fastCache->delete($this->getPrefixedKey($key));
 		$this->slowCache->remove($key, 'default', true);
 	}
 

--- a/src/UNL/Peoplefinder/Department/PersonnelSubtree.php
+++ b/src/UNL/Peoplefinder/Department/PersonnelSubtree.php
@@ -6,7 +6,7 @@ class UNL_Peoplefinder_Department_PersonnelSubtree extends ArrayIterator
     function __construct($mixed)
     {
         // Bump the allowed execution time to prevent timeouts due to potential slow load
-        set_time_limit (300); // 300 seconds = 5 minutes
+        set_time_limit (600); // 600 seconds = 10 minutes
 
         // Increase result limit for this type of search
         UNL_Peoplefinder::$resultLimit = 500;

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -6,7 +6,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
      *
      * @param string
      */
-    static public $ldapServer = 'ldaps://ldap.unl.edu';
+    public static $ldapServer = 'ldaps://ldap.unl.edu';
 
     /**
      * LDAP Connection bind distinguised name
@@ -14,7 +14,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
      * @var string
      * @ignore
      */
-    static public $bindDN = 'uid=insertyouruidhere,ou=service,dc=unl,dc=edu';
+    public static $bindDN = 'uid=insertyouruidhere,ou=service,dc=unl,dc=edu';
 
     /**
      * LDAP connection password.
@@ -22,11 +22,11 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
      * @var string
      * @ignore
      */
-    static public $bindPW             = 'putyourpasswordhere';
-    static public $baseDN             = 'ou=people,dc=unl,dc=edu';
-    static public $ldapTimeout        = 10;
-    static public $cacheTimeout       = 28800; //8 hours
-    static public $checkCache         = TRUE;
+    public static $bindPW             = 'putyourpasswordhere';
+    public static $baseDN             = 'ou=people,dc=unl,dc=edu';
+    public static $ldapTimeout        = 10;
+    public static $cacheTimeout       = 86400; // cache for one day
+    public static $resetCache         = FALSE;
 
     /**
      * Attribute arrays
@@ -190,7 +190,11 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         //Our key will most likely exceed the memcached key length limit, so reduce it
         $cache_key = 'ldap-'.md5($cache_key);
 
-        if (self::$checkCache === TRUE && $result = $cache->get($cache_key)) {
+        if (self::$resetCache) {
+           $cache->remove($cache_key);
+        }
+
+        if ($result = $cache->get($cache_key)) {
             $result = unserialize($result);
 
             if ($setResult) {

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -193,9 +193,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
 
         if ($this->resetCache === TRUE) {
            $cache->remove($cache_key);
-        }
-
-        if ($result = $cache->get($cache_key)) {
+        } elseif ($result = $cache->get($cache_key)) {
             $result = unserialize($result);
 
             if ($setResult) {

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -481,6 +481,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
 
         // Attempt to fix the data based on Oracle sourced information such as the `mail` attribute.
         $oracle =  new UNL_Peoplefinder_Driver_OracleDB();
+        if ($this->resetCache === TRUE) {
+            $oracle->resetCache();
+        }
         $results = $oracle->fixLDAPEntries($results);
 
         return $results;

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -184,15 +184,13 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
             $dn = self::$baseDN;
         }
 
-        if (self::$checkCache === TRUE) {
-            $cache = $this->getCache();
-        }
+        $cache = $this->getCache();
 
         $cache_key = $filter . '-' . implode(',', $attributes) . '-' . $setResult . '-' . $dn;
         //Our key will most likely exceed the memcached key length limit, so reduce it
         $cache_key = 'ldap-'.md5($cache_key);
 
-        if ($result = $cache->get($cache_key)) {
+        if (self::$checkCache === TRUE && $result = $cache->get($cache_key)) {
             $result = unserialize($result);
 
             if ($setResult) {

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -26,7 +26,8 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     public static $baseDN             = 'ou=people,dc=unl,dc=edu';
     public static $ldapTimeout        = 10;
     public static $cacheTimeout       = 86400; // cache for one day
-    public static $resetCache         = FALSE;
+
+    private $resetCache = FALSE;
 
     /**
      * Attribute arrays
@@ -190,7 +191,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         //Our key will most likely exceed the memcached key length limit, so reduce it
         $cache_key = 'ldap-'.md5($cache_key);
 
-        if (self::$resetCache) {
+        if ($this->resetCache) {
            $cache->remove($cache_key);
         }
 
@@ -553,5 +554,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     public function __destruct()
     {
         $this->unbind();
+    }
+
+    public function resetCache() {
+        $this->resetCache = TRUE;
     }
 }

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -191,9 +191,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         //Our key will most likely exceed the memcached key length limit, so reduce it
         $cache_key = 'ldap-'.md5($cache_key);
 
-        if ($this->resetCache === TRUE) {
-           $cache->remove($cache_key);
-        } elseif ($result = $cache->get($cache_key)) {
+        $this->checkKeyForCacheReset($cache, $cache_key);
+
+        if ($result = $cache->get($cache_key)) {
             $result = unserialize($result);
 
             if ($setResult) {
@@ -560,5 +560,11 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
 
     public function resetCache() {
         $this->resetCache = TRUE;
+    }
+
+    public function checkKeyForCacheReset($cache, $key) {
+        if ($this->resetCache === TRUE) {
+            $cache->remove($key);
+        }
     }
 }

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -481,9 +481,8 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
 
         // Attempt to fix the data based on Oracle sourced information such as the `mail` attribute.
         $oracle =  new UNL_Peoplefinder_Driver_OracleDB();
-        if ($this->resetCache === TRUE) {
-            $oracle->resetCache();
-        }
+        $oracle->resetCache();
+        
         $results = $oracle->fixLDAPEntries($results);
 
         return $results;

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -466,9 +466,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     protected static function normalizeLdapEntries(array $entries, $resetCache = FALSE)
     {
         $entries = UNL_Peoplefinder_Driver_LDAP_Util::filterArrayByKeys($entries, 'is_int');
-        if ($resetCache) {
-						$entry = current($entries);
-        }
+	      $entry = current($entries);
         if ($entry instanceof UNL_Peoplefinder_Driver_LDAP_Entry) {
             return $entries;
         }
@@ -481,7 +479,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
 
         // Attempt to fix the data based on Oracle sourced information such as the `mail` attribute.
         $oracle =  new UNL_Peoplefinder_Driver_OracleDB();
-        $oracle->resetCache();
+        if ($resetCache) {
+            $oracle->resetCache();
+        }
 
         $results = $oracle->fixLDAPEntries($results);
 

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -191,7 +191,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         //Our key will most likely exceed the memcached key length limit, so reduce it
         $cache_key = 'ldap-'.md5($cache_key);
 
-        if ($this->resetCache) {
+        if ($this->resetCache === TRUE) {
            $cache->remove($cache_key);
         }
 

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -251,7 +251,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
             return [];
         }
 
-        $result = self::normalizeLdapEntries(@ldap_get_entries($this->linkID, $sr));
+        $result = self::normalizeLdapEntries(@ldap_get_entries($this->linkID, $sr), $this->resetCache);
 
         if ($setResult) {
             $this->lastResult = $this->caseInsensitiveSortLDAPResults($result);
@@ -324,7 +324,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     {
         // Load the Sample User so a string comparison to their name can be done.
         if (isset(UNL_Peoplefinder::$sampleUID)) {
-            $result = self::normalizeLdapEntries(self::$samplePersonLDAP);
+            $result = self::normalizeLdapEntries(self::$samplePersonLDAP, $this->resetCache);
             $sampleRecord = self::recordFromLDAPEntry(current($result));
             $this->lastResult = $result;
         }
@@ -425,7 +425,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     public function getUID($uid)
     {
         if ($uid == UNL_Peoplefinder::$sampleUID) {
-            $r = self::normalizeLdapEntries(self::$samplePersonLDAP);
+            $r = self::normalizeLdapEntries(self::$samplePersonLDAP, $this->resetCache);
         } else {
             $filter = new UNL_Peoplefinder_Driver_LDAP_UIDFilter($uid);
             $r = $this->query($filter->__toString(), $this->detailAttributes, false);
@@ -465,10 +465,12 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         return new UNL_Peoplefinder_Person_Roles(['iterator' => new ArrayIterator($results)]);
     }
 
-    protected static function normalizeLdapEntries(array $entries)
+    protected static function normalizeLdapEntries(array $entries, $resetCache = FALSE)
     {
         $entries = UNL_Peoplefinder_Driver_LDAP_Util::filterArrayByKeys($entries, 'is_int');
-        $entry = current($entries);
+        if ($resetCache) {
+						$entry = current($entries);
+        }
         if ($entry instanceof UNL_Peoplefinder_Driver_LDAP_Entry) {
             return $entries;
         }
@@ -482,7 +484,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
         // Attempt to fix the data based on Oracle sourced information such as the `mail` attribute.
         $oracle =  new UNL_Peoplefinder_Driver_OracleDB();
         $oracle->resetCache();
-        
+
         $results = $oracle->fixLDAPEntries($results);
 
         return $results;

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -26,6 +26,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     static public $baseDN             = 'ou=people,dc=unl,dc=edu';
     static public $ldapTimeout        = 10;
     static public $cacheTimeout       = 28800; //8 hours
+    static public $checkCache         = TRUE;
 
     /**
      * Attribute arrays
@@ -183,7 +184,9 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
             $dn = self::$baseDN;
         }
 
-        $cache = $this->getCache();
+        if (self::$checkCache === TRUE) {
+            $cache = $this->getCache();
+        }
 
         $cache_key = $filter . '-' . implode(',', $attributes) . '-' . $setResult . '-' . $dn;
         //Our key will most likely exceed the memcached key length limit, so reduce it

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -9,9 +9,9 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
     public static $connection_host;
     public static $connection_port;
     public static $connection_service;
-    public static $resetCache = FALSE;
 
     private $conn;
+    private $resetCache = FALSE;
 
     /** Sample Data Set in Config File */
     public static $sampleFixLDAPEntries;
@@ -40,7 +40,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
         //Use md5 so we don't exceed the memcached key length
         $cache_key = 'oracle_query_' .  md5($statement) . '--' . md5(serialize($params));
 
-        if (self::$resetCache) {
+        if ($this->resetCache) {
             $cache->remove($cache_key);
         }
 
@@ -305,5 +305,9 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
         ]);
 
         return $cache;
+    }
+
+    protected function resetCache() {
+        $this->resetCache = TRUE;
     }
 }

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -40,7 +40,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
         //Use md5 so we don't exceed the memcached key length
         $cache_key = 'oracle_query_' .  md5($statement) . '--' . md5(serialize($params));
 
-        if ($this->resetCache) {
+        if ($this->resetCache === TRUE) {
             $cache->remove($cache_key);
         }
 

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -9,6 +9,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
     public static $connection_host;
     public static $connection_port;
     public static $connection_service;
+    public static $resetCache = FALSE;
 
     private $conn;
 
@@ -38,6 +39,10 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
         
         //Use md5 so we don't exceed the memcached key length
         $cache_key = 'oracle_query_' .  md5($statement) . '--' . md5(serialize($params));
+
+        if (self::$resetCache) {
+            $cache->remove($cache_key);
+        }
 
         if ($result = $cache->get($cache_key)) {
             $result = unserialize($result);

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -307,7 +307,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
         return $cache;
     }
 
-    protected function resetCache() {
+    public function resetCache() {
         $this->resetCache = TRUE;
     }
 }


### PR DESCRIPTION
Added logic to allow page to rendered without cached data and to reset the cache items for the page with the new data by adding `reset-cache` to the query string of the page. Cache items include LDAP and Oracle queries involved in the collecting the data of the page.

Example: https://directory-test.unl.edu/departments/50000955/personnelsubtree?format=xml&reset-cache

Also added a script to prime the departments used for digital signage. This script could be run daily to prime the cache for those departments, but I'll suggest that Nate M. uses the query string instead and only pull the data once a day.