### PR TITLE
Updates to prevent retirees from displaying in directory

### DIFF
--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -26,6 +26,21 @@
  */
 class UNL_Peoplefinder
 {
+	const ORG_UNIT_NUMBER_RETIREE = 50001351;
+	const AFFILIATION_STUDENT = 'student';
+	const AFFILIATION_GRADUATED = 'graduated';
+	const AFFILIATION_FACULTY = 'faculty';
+	const AFFILIATION_STAFF = 'staff';
+	const AFFILIATION_AFFILIATE = 'affiliate';
+	const AFFILIATION_VOLUNTEER = 'volunteer';
+	const AFFILIATION_RETIREE = 'retiree';
+	const AFFILIATION_EMERITI = 'emeriti';
+	const AFFILIATION_GUEST = 'guest';
+	const AFFILIATION_CONTINUE_SERVICES = 'continue services';
+	const AFFILIATION_RIF = 'rif';
+	const AFFILIATION_OVERRIDE = 'override'; // (will exist in guest ou)
+	const AFFILIATION_SPONSORED = 'sponsored'; // (will exist in guest ou)
+
     public static $resultLimit = 250;
 
     public static $url = '';
@@ -93,19 +108,13 @@ class UNL_Peoplefinder
      * @var array
      */
     public static $displayedAffiliations = array(
-        'student',
-//        'graduated',
-        'faculty',
-        'staff',
-        'affiliate',
-        'volunteer',
-//        'retiree',
-        'emeriti',
-//        'continue services',
-//        'rif',
-//        'override',  // (will exist in guest ou)
-//        'sponsored', // (will exist in guest ou)
-        );
+	    self::AFFILIATION_STUDENT,
+	    self::AFFILIATION_FACULTY,
+	    self::AFFILIATION_STAFF,
+	    self::AFFILIATION_AFFILIATE,
+	    self::AFFILIATION_VOLUNTEER,
+	    self::AFFILIATION_EMERITI,
+	);
 
     protected static $replacement_data = array();
 

--- a/src/UNL/Peoplefinder/Driver/LDAP/AdvancedFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/AdvancedFilter.php
@@ -39,12 +39,12 @@ class UNL_Peoplefinder_Driver_LDAP_AdvancedFilter
         // Determine the eduPersonPrimaryAffiliation to query by
         switch ($eppa) {
             case 'stu':
-            case 'student':
+            case UNL_Peoplefinder::AFFILIATION_STUDENT:
                 $primaryAffiliation = '(eduPersonPrimaryAffiliation=student)';
                 break;
             case 'fs':
-            case 'faculty':
-            case 'staff':
+            case UNL_Peoplefinder::AFFILIATION_FACULTY:
+            case UNL_Peoplefinder::AFFILIATION_STAFF:
                 $primaryAffiliation = '(|(eduPersonPrimaryAffiliation=faculty)(eduPersonPrimaryAffiliation=staff))';
                 break;
             default:

--- a/src/UNL/Peoplefinder/Driver/LDAP/AffiliationFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/AffiliationFilter.php
@@ -1,15 +1,15 @@
 <?php
 class UNL_Peoplefinder_Driver_LDAP_AffiliationFilter extends UNL_Peoplefinder_Driver_LDAP_StandardFilter
 {
-    protected $affiliation = 'staff';
+    protected $affiliation = UNL_Peoplefinder::AFFILIATION_STAFF;
 
     public function __construct($query, $affiliation, $operator = '&', $wild = false)
     {
         switch($affiliation) {
-            case 'student':
-            case 'faculty':
-            case 'staff':
-            case 'guest':
+            case UNL_Peoplefinder::AFFILIATION_STUDENT:
+            case UNL_Peoplefinder::AFFILIATION_FACULTY:
+            case UNL_Peoplefinder::AFFILIATION_STAFF:
+            case UNL_Peoplefinder::AFFILIATION_GUEST:
                 $this->affiliation = $affiliation;
                 break;
         }

--- a/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/Entry.php
@@ -9,9 +9,9 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
      * @var array
      */
     public static $affiliationMapping = array(
-        't' => 'faculty',
-        'faculty/executive' => 'faculty',
-        'administrative' => 'staff',
+        't' => UNL_Peoplefinder::AFFILIATION_FACULTY,
+        'faculty/executive' => UNL_Peoplefinder::AFFILIATION_FACULTY,
+        'administrative' => UNL_Peoplefinder::AFFILIATION_STAFF,
     );
 
     public function __construct(array $entry)
@@ -60,12 +60,12 @@ class UNL_Peoplefinder_Driver_LDAP_Entry extends ArrayObject
             foreach ($entry['edupersonprimaryaffiliation'] as $key => $value) {
                 
                 //Prevent student phone numbers from showing
-                if ($entry['edupersonprimaryaffiliation'][$key] == 'student') {
+                if ($entry['edupersonprimaryaffiliation'][$key] == UNL_Peoplefinder::AFFILIATION_STUDENT) {
                     unset($entry['telephonenumber']);
                 }
 
                 //Prevent student phone numbers and other protected from showing (in case the upstream data source send them to us on accident)
-                if ($entry['edupersonprimaryaffiliation'][$key] == 'student') {
+                if ($entry['edupersonprimaryaffiliation'][$key] == UNL_Peoplefinder::AFFILIATION_STUDENT) {
                     unset(
                         $entry['telephonenumber'],
                         $entry['postaladdress'],

--- a/src/UNL/Peoplefinder/Driver/LDAP/TelephoneFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/TelephoneFilter.php
@@ -25,9 +25,9 @@ class UNL_Peoplefinder_Driver_LDAP_TelephoneFilter
         }
 
         switch ($affiliation) {
-            case 'faculty':
-            case 'staff':
-            case 'student':
+            case UNL_Peoplefinder::AFFILIATION_FACULTY:
+            case UNL_Peoplefinder::AFFILIATION_STAFF:
+            case UNL_Peoplefinder::AFFILIATION_STUDENT:
                 $this->affiliation = $affiliation;
                 break;
         }

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -273,7 +273,7 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
             // Remove the student affiliation if the privacy flag is set
             if (!empty($row['NU_FERPA']) && isset($entries[$key]['edupersonaffiliation'])) {
                 $value = new UNL_Peoplefinder_Driver_LDAP_Multivalue(
-                    array_diff(iterator_to_array($entries[$key]['edupersonaffiliation']), array('student'))
+                    array_diff(iterator_to_array($entries[$key]['edupersonaffiliation']), array(UNL_Peoplefinder::AFFILIATION_STUDENT))
                 );
 
                 $entries[$key]['edupersonaffiliation'] = $value;

--- a/src/UNL/Peoplefinder/Person/Roles.php
+++ b/src/UNL/Peoplefinder/Person/Roles.php
@@ -39,7 +39,8 @@ class UNL_Peoplefinder_Person_Roles extends IteratorIterator implements Countabl
     }
 
     public function isDisplayableRole($role) {
-        if ($role->unlRoleHROrgUnitNumber == UNL_Peoplefinder::ORG_UNIT_NUMBER_RETIREE) {
+        if ($role->unlRoleHROrgUnitNumber == UNL_Peoplefinder::ORG_UNIT_NUMBER_RETIREE ||
+	        strtolower($role->description) == 'retiree') {
             return false;
         }
         return true;

--- a/src/UNL/Peoplefinder/Person/Roles.php
+++ b/src/UNL/Peoplefinder/Person/Roles.php
@@ -38,12 +38,12 @@ class UNL_Peoplefinder_Person_Roles extends IteratorIterator implements Countabl
         return $this;
     }
 
-	public function isDisplayableRole($role) {
-		if ($role->unlRoleHROrgUnitNumber === UNL_Peoplefinder::ORG_UNIT_NUMBER_RETIREE) {
-			return false;
-		}
-		return true;
-	}
+    public function isDisplayableRole($role) {
+        if ($role->unlRoleHROrgUnitNumber == UNL_Peoplefinder::ORG_UNIT_NUMBER_RETIREE) {
+            return false;
+        }
+        return true;
+    }
 
     /**
      * Get the number of roles this person has

--- a/src/UNL/Peoplefinder/Person/Roles.php
+++ b/src/UNL/Peoplefinder/Person/Roles.php
@@ -38,6 +38,13 @@ class UNL_Peoplefinder_Person_Roles extends IteratorIterator implements Countabl
         return $this;
     }
 
+	public function isDisplayableRole($role) {
+		if ($role->unlRoleHROrgUnitNumber === UNL_Peoplefinder::ORG_UNIT_NUMBER_RETIREE) {
+			return false;
+		}
+		return true;
+	}
+
     /**
      * Get the number of roles this person has
      *

--- a/src/UNL/Peoplefinder/Record.php
+++ b/src/UNL/Peoplefinder/Record.php
@@ -368,10 +368,10 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
         }
         
         $affiliationsWithAppointments = [
-            'staff',
-            'faculty',
-            'volunteer',
-            'affiliate'
+            UNL_Peoplefinder::AFFILIATION_STAFF,
+            UNL_Peoplefinder::AFFILIATION_FACULTY,
+            UNL_Peoplefinder::AFFILIATION_VOLUNTEER,
+            UNL_Peoplefinder::AFFILIATION_AFFILIATE
         ];
 
         $affiliations = $this->eduPersonAffiliation;
@@ -407,13 +407,13 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
             }
         }
 
-        return $this->title;
+        return ucwords($this->title);
     }
 
     public function hasStudentInformation()
     {
         if ($this->eduPersonAffiliation instanceof ArrayIterator &&
-            !in_array('student', iterator_to_array($this->eduPersonAffiliation))) {
+            !in_array(UNL_Peoplefinder::AFFILIATION_STUDENT, iterator_to_array($this->eduPersonAffiliation))) {
             return false;
         }
 
@@ -615,7 +615,7 @@ class UNL_Peoplefinder_Record implements UNL_Peoplefinder_Routable, Serializable
 
     public function isPrimarilyStudent()
     {
-        return $this->eduPersonPrimaryAffiliation == 'student';
+        return $this->eduPersonPrimaryAffiliation == UNL_Peoplefinder::AFFILIATION_STUDENT;
     }
 
     public function getRoles()

--- a/www/templates/html/Peoplefinder/Person/Roles.tpl.php
+++ b/www/templates/html/Peoplefinder/Person/Roles.tpl.php
@@ -1,6 +1,11 @@
 <ul class="roles dcf-list-bare dcf-m-0">
     <?php foreach ($context as $role): ?>
     <?php
+    if (!$context->isDisplayableRole($role)) {
+        // skip roles flagged not to display
+        continue;
+    }
+
     if (!$org = UNL_Officefinder_Department::getByorg_unit($role->unlRoleHROrgUnitNumber)) {
         // Couldn't retrieve this org's record from officefinder
         continue;

--- a/www/templates/vcard/Peoplefinder/Record.tpl.php
+++ b/www/templates/vcard/Peoplefinder/Record.tpl.php
@@ -14,7 +14,7 @@ if (isset($context->unlHROrgUnitNumber)) {
     }
     
 }
-if (isset($context->mail) && ($context->eduPersonPrimaryAffiliation != 'student')) {
+if (isset($context->mail) && ($context->eduPersonPrimaryAffiliation != UNL_Peoplefinder::AFFILIATION_STUDENT)) {
     echo "EMAIL;type=INTERNET;type=WORK;type=pref:".$context->mail."\n";
 }
 if ($context->eduPersonPrimaryAffiliation != "student") {


### PR DESCRIPTION
Note: This PR branch has been applied to both the Production (https://directory.unl.edu) and Test (https://directory-test.unl.edu) sites for testing.

Changes made:
* Add affiliation constants
* Prevent person records with only Retiree and Volunteer affiliations.
* Prevent display of roles of Retirees Org Unit or with title/description of 'retiree'

I'm not sure if these changes will prevent all retirees or retiree information from displaying or if some valid person may be excluded, but it should handle most cases.
