### PR TITLE
added building searches

### DIFF
--- a/src/UNL/Peoplefinder.php
+++ b/src/UNL/Peoplefinder.php
@@ -86,6 +86,7 @@ class UNL_Peoplefinder
     protected $uidViews = [
         'record',
         'avatar',
+        'buildinglisting',
     ];
 
     public $view_map = [
@@ -98,6 +99,7 @@ class UNL_Peoplefinder
         'developers' => 'UNL_Peoplefinder_Developers',
         'alphalisting' => 'UNL_Peoplefinder_PersonList_AlphaListing',
         'facultyedu' => 'UNL_Peoplefinder_FacultyEducationList',
+        'buildinglisting' => 'UNL_Peoplefinder_PersonList_Building',
     ];
 
     /**

--- a/src/UNL/Peoplefinder/Driver/LDAP.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP.php
@@ -400,6 +400,21 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
     }
 
     /**
+     * Get an array of records which matches by the building
+     *
+     * @param string $q           EG: 472-1598
+     * @param string $affiliation eduPersonAffiliation, eg staff/faculty/student
+     *
+     * @return array(UNL_Peoplefinder_Record)
+     */
+    public function getBuildingMatches($query, $affiliation = null)
+    {
+        $filter = new UNL_Peoplefinder_Driver_LDAP_BuildingFilter($query, $affiliation);
+        $this->query($filter->__toString(), $this->detailAttributes);
+        return $this->getRecordsFromResults();
+    }
+
+    /**
      * Get the ldap record for a specific uid eg:bbieber2
      *
      * @param string $uid The unique ID for the user you want to get.
@@ -414,6 +429,7 @@ class UNL_Peoplefinder_Driver_LDAP implements UNL_Peoplefinder_DriverInterface
             $filter = new UNL_Peoplefinder_Driver_LDAP_UIDFilter($uid);
             $r = $this->query($filter->__toString(), $this->detailAttributes, false);
         }
+        debug_print_backtrace();
 
         if (empty($r) || !self::displayableLDAPEntry(current($r))) {
             throw new Exception('Cannot find that UID.', 404);

--- a/src/UNL/Peoplefinder/Driver/LDAP/BuildingFilter.php
+++ b/src/UNL/Peoplefinder/Driver/LDAP/BuildingFilter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Builds a simple telephone filter for searching for records.
+ *
+ * PHP version 5
+ *
+ * @category  Default
+ * @package   UNL_Peoplefinder
+ * @author    Thomas Neumann <tneumann9@unl.edu>
+ * @copyright 2022 Regents of the University of Nebraska
+ * @license   https://www1.unl.edu/wdn/wiki/Software_License BSD License
+ * @link      https://peoplefinder.unl.edu/
+ */
+class UNL_Peoplefinder_Driver_LDAP_BuildingFilter
+{
+    private $_filter;
+
+    protected $affiliation;
+
+    public function __construct($q, $affiliation = null)
+    {
+        if (!empty($q)) {
+            $q = preg_replace('/\D/', '', $q);
+            $this->_filter = '(postalAddress='.$q.'*)';
+        }
+
+        switch ($affiliation) {
+            case UNL_Peoplefinder::AFFILIATION_FACULTY:
+            case UNL_Peoplefinder::AFFILIATION_STAFF:
+            case UNL_Peoplefinder::AFFILIATION_STUDENT:
+                $this->affiliation = $affiliation;
+                break;
+        }
+    }
+
+    public function __toString()
+    {
+        if ($this->affiliation) {
+            $this->_filter = '(&'.$this->_filter.'(eduPersonAffiliation='.$this->affiliation.'))';
+        }
+        $this->_filter = UNL_Peoplefinder_Driver_LDAP_Util::wrapGlobalExclusions($this->_filter);
+        return $this->_filter;
+    }
+}

--- a/src/UNL/Peoplefinder/Driver/OracleDB.php
+++ b/src/UNL/Peoplefinder/Driver/OracleDB.php
@@ -189,6 +189,11 @@ class UNL_Peoplefinder_Driver_OracleDB implements UNL_Peoplefinder_DriverInterfa
     {
         return array();
     }
+
+    function getBuildingMatches($query, $affiliation = null)
+    {
+        return array();
+    }
     
     public function getUID($uid)
     {

--- a/src/UNL/Peoplefinder/Driver/WebService.php
+++ b/src/UNL/Peoplefinder/Driver/WebService.php
@@ -76,6 +76,23 @@ class UNL_Peoplefinder_Driver_WebService implements UNL_Peoplefinder_DriverInter
     }
 
     /**
+     * Get matches for a building search
+     * 
+     * @param string $query       Numerical search query
+     * @param string $affiliation eduPersonAffiliation, eg, student, staff, faculty
+     * 
+     * @return UNL_Peoplefinder_SearchResults
+     */
+    function getBuildingMatches($query, $affiliation = null)
+    {
+        $results = file_get_contents($this->service_url.'?q='.urlencode($query).'&format=php&affiliation='.urlencode($affiliation).'&method=getBuildingMatches');
+        if ($results) {
+            $results = unserialize($results);
+        }
+        return $results;
+    }
+
+    /**
      * Get an individual's record within the directory.
      * 
      * @param string $uid Unique ID for the user, eg: bbieber2

--- a/src/UNL/Peoplefinder/DriverInterface.php
+++ b/src/UNL/Peoplefinder/DriverInterface.php
@@ -40,6 +40,14 @@ interface UNL_Peoplefinder_DriverInterface
     function getPhoneMatches($query, $affiliation = null);
 
     /**
+     * return matches for a building search
+     *
+     * @param string $query       Phone number eg: ALEX
+     * @param string $affiliation eduPersonAffiliation, eg staff/faculty/student
+     */
+    function getBuildingMatches($query, $affiliation = null);
+
+    /**
      * Get results by organization
      * 
      * @param string $query       The organization name, eg: University Communications

--- a/src/UNL/Peoplefinder/PersonList/Building.php
+++ b/src/UNL/Peoplefinder/PersonList/Building.php
@@ -1,0 +1,46 @@
+<?php
+class UNL_Peoplefinder_PersonList_Building extends AppendIterator
+{
+    public $options = array();
+    
+    public $user;
+
+    function __construct($options = array())
+    {
+        parent::__construct();
+
+        // Login is required to view this
+        $this->user = UNL_Officefinder::getUser(true);
+
+
+        if ($options['format'] != 'html') {
+            throw new Exception('This is not your personal service');
+        }
+
+        $this->options = $options;
+
+        UNL_Peoplefinder::$resultLimit = 5000;
+
+        /* @var $pf UNL_Peoplefinder */
+        $pf = $options['peoplefinder'];
+
+        if (!$pf->driver instanceof UNL_Peoplefinder_Driver_LDAP) {
+            throw new Exception('Whoah whoah, that ain\'t gonna happen unless you have direct LDAP access');
+        }
+
+        // Set the attributes requested to only a subset to save memory
+        $pf->driver->detailAttributes = array(
+            'sn',
+            'cn',
+            'telephoneNumber',
+            'givenName',
+            'title',
+            'uid',
+            'unlHROrgUnitNumber',
+            'unlHRPrimaryDepartment',
+        );
+
+        $results = $pf->getBuildingMatches($this->options['building'], 'faculty');
+        $this->append(new UNL_Peoplefinder_SearchResults(array('results'=>$results)));
+    }
+}

--- a/www/templates/html/Peoplefinder/PersonList/Building.tpl.php
+++ b/www/templates/html/Peoplefinder/PersonList/Building.tpl.php
@@ -1,0 +1,2 @@
+<?php
+echo $savvy->render($context, 'Peoplefinder/SearchResults.tpl.php');


### PR DESCRIPTION
Is it possible to search by building rather than org unit? OR, is it possible to combine multiple org units into one query?
 
Example use case: Combining Chemistry and BPAC employees into one XML result.
Chem: [https://directory.unl.edu/departments/50001078/personnelsubtree?format=xml](https://directory.unl.edu/departments/50001078/personnelsubtree?format=xml)
BPAC: [https://directory.unl.edu/departments/50012176/personnelsubtree?format=xml](https://directory.unl.edu/departments/50012176/personnelsubtree?format=xml)