### PR TITLE
Do not require login for department page, but force it for person info

### DIFF
--- a/src/UNL/Officefinder.php
+++ b/src/UNL/Officefinder.php
@@ -81,8 +81,10 @@ class UNL_Officefinder
 
         self::checkLogout();
 
-        if (in_array($this->options['format'], ['html'])) {
-            self::authenticate(true);
+        if (array_key_exists('unl_sso', $_COOKIE) && !empty($_COOKIE['unl_sso'])) {
+            if (in_array($this->options['format'], ['html'])) {
+                self::authenticate(true);
+            }
         }
 
         // prevent unauthenticated edit rendering

--- a/src/UNL/PersonInfo.php
+++ b/src/UNL/PersonInfo.php
@@ -82,7 +82,7 @@ class UNL_PersonInfo implements UNL_PersonInfo_PageNoticeInterface
 
         // If it is an HTML request check if they are authenticated
         if (in_array($this->options['format'], ['html'])) {
-            self::authenticate(true);
+            self::authenticate();
         }
 
         try {


### PR DESCRIPTION
Department was supposed to do a gateway auth but that does not seem to be working. This change will re-add the unl_sso cookie check and authenticate you if it finds it